### PR TITLE
Ensure filterByCallback returns object of called class

### DIFF
--- a/model/ArrayList.php
+++ b/model/ArrayList.php
@@ -548,7 +548,7 @@ class ArrayList extends ViewableData implements SS_List, SS_Filterable, SS_Sorta
 			));
 		}
 
-		$output = self::create();
+		$output = static::create();
 
 		foreach($this as $item) {
 			if(call_user_func($callback, $item, $this)) $output->push($item);

--- a/model/ArrayList.php
+++ b/model/ArrayList.php
@@ -548,7 +548,7 @@ class ArrayList extends ViewableData implements SS_List, SS_Filterable, SS_Sorta
 			));
 		}
 
-		$output = ArrayList::create();
+		$output = self::create();
 
 		foreach($this as $item) {
 			if(call_user_func($callback, $item, $this)) $output->push($item);


### PR DESCRIPTION
This change ensures that filterByCallback returns a filtered list of the same called class, if ArrayList is extended.

The current filterByCallback always instantiates an ArrayList with the filtered results, which is probably not what you want if you extend ArrayList.

eg; currently this occurs

```
class MyArrayList extends ArrayList {
   public function sayHello() {
      return 'hi'; 
   }
}

$list = MyArrayList::create();
//populate $list here
$filtered = $list::filterByCallback($someCallback);

$filtered->sayHello();  
// -> The method 'sayHello' does not exist on 'ArrayList' 
```
